### PR TITLE
Hotfix, matching questions choices implemented as lists

### DIFF
--- a/app/Models/Quiz.py
+++ b/app/Models/Quiz.py
@@ -1,9 +1,11 @@
 import json
 import uuid
 from typing import List
-from app.Models.Questions import Question, MultipleChoiceQuestion, Question, MatchingQuestion, ShortAnswerQuestion, FillInTheBlankQuestion
+from app.Models.Questions import Question, MultipleChoiceQuestion, Question, MatchingQuestion, ShortAnswerQuestion, \
+    FillInTheBlankQuestion
 from app.StorageHandler import write_to_file, load_file_as_json, initialize
-from app.Models.Response import Response, MultipleChoiceResponse, MatchingResponse, ShortAnswerResponse, FillInTheBlankResponse
+from app.Models.Response import Response, MultipleChoiceResponse, MatchingResponse, ShortAnswerResponse, \
+    FillInTheBlankResponse
 from app.JSONHandler import ProjectJSONEncoder
 
 
@@ -74,8 +76,8 @@ if __name__ == '__main__':
                                                       answer='Mike')
     quiz.add_question_to_quiz(multiple_choice_question)
 
-    matching_question = MatchingQuestion(prompt="Match the following questions", left_choices={"A": 'Mike', "B": 'Ike'},
-                                         right_choices={'C': 'Ike', 'D': 'Mike'}, answer={'A': 'C', 'B': 'D'})
+    matching_question = MatchingQuestion(prompt="Match the following questions", left_choices=['Mike', 'Ike'],
+                                         right_choices=['Ike', 'Mike'], answer={'Mike': 'Ike', 'Ike': 'Mike'})
     quiz.add_question_to_quiz(matching_question)
 
     short_answer_question = ShortAnswerQuestion(prompt="Who is the best?", answer='YOU')
@@ -93,7 +95,7 @@ if __name__ == '__main__':
     first_question.add_response(response)
     second_question = quiz.get_question(1)
 
-    response_question_two = MatchingResponse({'A': 'C', 'B': 'D'}, '1345125', 'Brian')
+    response_question_two = MatchingResponse({'Mike': None, 'Ike': None}, '1345125', 'Brian')
     second_question.add_response(response_question_two)
 
     third_question = quiz.get_question(2)
@@ -107,4 +109,3 @@ if __name__ == '__main__':
     Quiz.write_quiz(quiz, taken=True)
     quiz = Quiz.load_quiz("Brian's First Quiz", taken=True)
     print(json.dumps(quiz, cls=ProjectJSONEncoder))
-

--- a/app/quizzes/taken/Brian's First Quiz
+++ b/app/quizzes/taken/Brian's First Quiz
@@ -1,11 +1,11 @@
 {
     "kind": "quiz",
-    "object_id": "7baa316d-7e41-4c3b-ae2f-9a26b16f2241",
+    "object_id": "8afc10ff-97b3-450b-8df4-28752fe9afa8",
     "name": "Brian's First Quiz",
     "questions": [
         {
             "kind": "question",
-            "object_id": "07c9e04b-4cad-4c50-aeee-805c89428c66",
+            "object_id": "cac85635-15c2-4f50-827d-60b2270c639a",
             "type": "multiple_choice",
             "prompt": "Who is the best?",
             "choices": [
@@ -25,28 +25,28 @@
         },
         {
             "kind": "question",
-            "object_id": "e41438e0-9f1b-452f-8b8d-114b2f0c0802",
+            "object_id": "4bcdc3d2-14e5-4576-88fd-081ac6fc2ef5",
             "type": "matching",
             "prompt": "Match the following questions",
-            "left_choices": {
-                "A": "Mike",
-                "B": "Ike"
-            },
-            "right_choices": {
-                "C": "Ike",
-                "D": "Mike"
-            },
+            "left_choices": [
+                "Mike",
+                "Ike"
+            ],
+            "right_choices": [
+                "Ike",
+                "Mike"
+            ],
             "answer": {
-                "A": "C",
-                "B": "D"
+                "Mike": "Ike",
+                "Ike": "Mike"
             },
             "responses": [
                 {
                     "kind": "response",
                     "type": "matching",
                     "answer_mapping": {
-                        "A": "C",
-                        "B": "D"
+                        "Mike": null,
+                        "Ike": null
                     },
                     "user_id": "1345125",
                     "nickname": "Brian"
@@ -55,7 +55,7 @@
         },
         {
             "kind": "question",
-            "object_id": "f49be826-a813-413f-b999-fab330d23329",
+            "object_id": "dbab7e2e-4dcf-4e46-ac49-0bdb150349b9",
             "type": "short_answer",
             "prompt": "Who is the best?",
             "answer": "YOU",
@@ -71,7 +71,7 @@
         },
         {
             "kind": "question",
-            "object_id": "9eda8ecb-50f1-4ec7-bcce-f5d6f00ae1bd",
+            "object_id": "9b35f072-426a-40a9-b7bf-5e6c578cef17",
             "type": "fill_in_the_blank",
             "before_prompt": "",
             "after_prompt": "are the best",

--- a/app/quizzes/untaken/Brian's First Quiz
+++ b/app/quizzes/untaken/Brian's First Quiz
@@ -1,11 +1,11 @@
 {
     "kind": "quiz",
-    "object_id": "7baa316d-7e41-4c3b-ae2f-9a26b16f2241",
+    "object_id": "8afc10ff-97b3-450b-8df4-28752fe9afa8",
     "name": "Brian's First Quiz",
     "questions": [
         {
             "kind": "question",
-            "object_id": "07c9e04b-4cad-4c50-aeee-805c89428c66",
+            "object_id": "cac85635-15c2-4f50-827d-60b2270c639a",
             "type": "multiple_choice",
             "prompt": "Who is the best?",
             "choices": [
@@ -17,26 +17,26 @@
         },
         {
             "kind": "question",
-            "object_id": "e41438e0-9f1b-452f-8b8d-114b2f0c0802",
+            "object_id": "4bcdc3d2-14e5-4576-88fd-081ac6fc2ef5",
             "type": "matching",
             "prompt": "Match the following questions",
-            "left_choices": {
-                "A": "Mike",
-                "B": "Ike"
-            },
-            "right_choices": {
-                "C": "Ike",
-                "D": "Mike"
-            },
+            "left_choices": [
+                "Mike",
+                "Ike"
+            ],
+            "right_choices": [
+                "Ike",
+                "Mike"
+            ],
             "answer": {
-                "A": "C",
-                "B": "D"
+                "Mike": "Ike",
+                "Ike": "Mike"
             },
             "responses": []
         },
         {
             "kind": "question",
-            "object_id": "f49be826-a813-413f-b999-fab330d23329",
+            "object_id": "dbab7e2e-4dcf-4e46-ac49-0bdb150349b9",
             "type": "short_answer",
             "prompt": "Who is the best?",
             "answer": "YOU",
@@ -44,7 +44,7 @@
         },
         {
             "kind": "question",
-            "object_id": "9eda8ecb-50f1-4ec7-bcce-f5d6f00ae1bd",
+            "object_id": "9b35f072-426a-40a9-b7bf-5e6c578cef17",
             "type": "fill_in_the_blank",
             "before_prompt": "",
             "after_prompt": "are the best",

--- a/app/tests/test_Questions.py
+++ b/app/tests/test_Questions.py
@@ -59,25 +59,25 @@ class TestQuestion(unittest.TestCase):
             "id": "d3d46649-4dbb-4d6b-b1fe-5f87f5b42756",
             "type": "matching",
             "prompt": "Match the following questions",
-            "left_choices": {
-                "A": "Mike",
-                "B": "Ike"
-            },
-            "right_choices": {
-                "C": "Ike",
-                "D": "Mike"
-            },
+            "left_choices": [
+                "Mike",
+                "Ike"
+            ],
+            "right_choices": [
+                "Ike",
+                "Mike"
+            ],
             "answer": {
-                "A": "C",
-                "B": "D"
+                "Mike": "Ike",
+                "Ike": "Mike",
             },
             "responses": [
                 {
                     "kind": "response",
                     "type": "matching",
                     "answer_mapping": {
-                        "A": "C",
-                        "B": "D"
+                        "Mike": "Ike",
+                        "Ike": "Mike"
                     },
                     "user_id": "1345125",
                     "nickname": "Brian"
@@ -129,16 +129,16 @@ class TestQuestion(unittest.TestCase):
     def test_add_response(self, mock_validate):
         # Not using the spec will not allow the isinstance method to work since it'll see MagicMock
         multiple_choice_question = MultipleChoiceQuestion(prompt="Who is the best?",
-                                                          choices={"A": 'Mike', "B": 'Domingo'},
-                                                          answer='A')
+                                                          choices=['Mike', 'Domingo'],
+                                                          answer='Mike')
         response = MagicMock(spec=MultipleChoiceResponse)
         response.get_type.return_value = 'multiple_choice'
-        response.json_data = {'choice': 'A'}
+        response.json_data = {'choice': 'Mike'}
         multiple_choice_question.add_response(response)
         mock_validate.assert_called()
         response = MagicMock(spec=MultipleChoiceResponse)
         response.get_type.return_value = 'matching'
-        response.json_data = {'choice': 'A'}
+        response.json_data = {'choice': 'Mike'}
         with self.assertRaises(ValueError):
             multiple_choice_question.add_response(response)
 
@@ -203,52 +203,51 @@ class TestMatchingQuestion(unittest.TestCase):
                                                                                                    '-4948-b47d'
                                                                                                    '-54248586986e')])
     def setUp(self, uuid_mock) -> None:
-        response_object = MatchingResponse({'A': 'C', 'B': 'D'}, '1345125', 'Brian')
+        response_object = MatchingResponse({'Mike': 'Ike', 'Ike': 'Mike'}, '1345125', 'Brian')
         self.responses = [
             {
                 "kind": "response",
                 "type": "matching",
                 "answer_mapping": {
-                    "A": "C",
-                    "B": "D"
+                    "Mike": "Ike",
+                    "Ike": "Mike"
                 },
                 "user_id": "1345125",
                 "nickname": "Brian"
             }
             ,
             response_object]
-        self.question = MatchingQuestion(prompt="Match the following questions", left_choices={"A": 'Mike', "B": 'Ike'},
-                                         right_choices={'C': 'Ike', 'D': 'Mike'}, answer={'A': 'C', 'B': 'D'})
+        self.question = MatchingQuestion(prompt="Match the following questions", left_choices=['Mike', 'Ike'],
+                                         right_choices=['Ike', 'Mike'], answer={'Mike': 'Ike', 'Ike': 'Mike'})
         self.answered_question = MatchingQuestion(prompt="Match the following questions",
-                                                  left_choices={"A": 'Mike', "B": 'Ike'},
-                                                  right_choices={'C': 'Ike', 'D': 'Mike'}, answer={'A': 'C', 'B': 'D'},
+                                                  left_choices=['Mike', 'Ike'],
+                                                  right_choices=['Ike', 'Mike'], answer={'Mike': 'Ike', 'Ike': 'Mike'},
                                                   responses=self.responses,
                                                   object_id='be24d525-8904-4948-b47d-54248586986d')
 
     def test_json_data(self):
         self.assertEqual(self.question.json_data,
-                         {'answer': {'A': 'C', 'B': 'D'},
-                          'object_id': 'be24d525-8904-4948-b47d-54248586986d',
+                         {'answer': {'Ike': 'Mike', 'Mike': 'Ike'},
                           'kind': 'question',
-                          'left_choices': {'A': 'Mike', 'B': 'Ike'},
+                          'left_choices': ['Mike', 'Ike'],
+                          'object_id': 'be24d525-8904-4948-b47d-54248586986d',
                           'prompt': 'Match the following questions',
                           'responses': [],
-                          'right_choices': {'C': 'Ike', 'D': 'Mike'},
-                          'type': 'matching'}
-                         )
+                          'right_choices': ['Ike', 'Mike'],
+                          'type': 'matching'})
 
     def test_validate_response(self):
         response = MagicMock()
-        self.question = MatchingQuestion(prompt="Match the following questions", left_choices={"A": 'Mike', "B": 'Ike'},
-                                         right_choices={'C': 'Ike', 'D': 'Mike'}, answer={'A': 'C', 'B': 'D'})
-        response.json_data = {'answer_mapping': {'A': 'C'}}
+        self.question = MatchingQuestion(prompt="Match the following questions", left_choices=['Mike', 'Ike'],
+                                         right_choices=['Ike', 'Mike'], answer={'Mike': 'Ike', 'Ike': 'Mike'})
+        response.json_data = {'answer_mapping': {'Mike': 'Ike', 'Ike': 'Mike'}}
         self.question.validate_response(response)
         invalid_response_one = MagicMock()
-        invalid_response_one.json_data = {'dog': 'A'}
+        invalid_response_one.json_data = {'dog': 'Ike'}
         with self.assertRaises(ValueError):
             self.question.validate_response(invalid_response_one)
         invalid_response_two = MagicMock()
-        invalid_response_two.json_data = {'answer_mapping': {'F': 'C'}}
+        invalid_response_two.json_data = {'answer_mapping': {'Mike': 'Bike'}}
         with self.assertRaises(ValueError):
             self.question.validate_response(invalid_response_two)
 
@@ -280,19 +279,7 @@ class TestShortAnswerQuestion(unittest.TestCase):
                          )
 
     def test_validate_response(self):
-        response = MagicMock()
-        self.question = MatchingQuestion(prompt="Match the following questions", left_choices={"A": 'Mike', "B": 'Ike'},
-                                         right_choices={'C': 'Ike', 'D': 'Mike'}, answer={'A': 'C', 'B': 'D'})
-        response.json_data = {'answer_mapping': {'A': 'C'}}
-        self.question.validate_response(response)
-        invalid_response_one = MagicMock()
-        invalid_response_one.json_data = {'dog': 'A'}
-        with self.assertRaises(ValueError):
-            self.question.validate_response(invalid_response_one)
-        invalid_response_two = MagicMock()
-        invalid_response_two.json_data = {'answer_mapping': {'F': 'C'}}
-        with self.assertRaises(ValueError):
-            self.question.validate_response(invalid_response_two)
+        pass
 
     def test_get_type(self):
         self.assertEqual(self.question.get_type(), 'short_answer')
@@ -326,19 +313,7 @@ class TestFillInTheBlankQuestion(unittest.TestCase):
         self.assertEqual(self.question.get_type(), 'fill_in_the_blank')
 
     def test_validate_response(self):
-        response = MagicMock()
-        self.question = MatchingQuestion(prompt="Match the following questions", left_choices={"A": 'Mike', "B": 'Ike'},
-                                         right_choices={'C': 'Ike', 'D': 'Mike'}, answer={'A': 'C', 'B': 'D'})
-        response.json_data = {'answer_mapping': {'A': 'C'}}
-        self.question.validate_response(response)
-        invalid_response_one = MagicMock()
-        invalid_response_one.json_data = {'dog': 'A'}
-        with self.assertRaises(ValueError):
-            self.question.validate_response(invalid_response_one)
-        invalid_response_two = MagicMock()
-        invalid_response_two.json_data = {'answer_mapping': {'F': 'C'}}
-        with self.assertRaises(ValueError):
-            self.question.validate_response(invalid_response_two)
+        pass
 
 
 if __name__ == '__main__':

--- a/app/tests/test_Quiz.py
+++ b/app/tests/test_Quiz.py
@@ -9,95 +9,95 @@ class TestQuiz(unittest.TestCase):
 
     def setUp(self) -> None:
         self.quiz_json = {
-    "kind": "quiz",
-    "object_id": "3945769a-9b6f-4feb-b292-f3e8958a59d3",
-    "name": "Brian's First Quiz",
-    "questions": [
-        {
-            "kind": "question",
-            "object_id": "751f9e7a-cbcc-41d8-816e-d65f6fdafe23",
-            "type": "multiple_choice",
-            "prompt": "Who is the best?",
-            "choices": [
-                "Mike",
-                "Domingo"
-            ],
-            "answer": "Mike",
-            "responses": [
+            "kind": "quiz",
+            "object_id": "3945769a-9b6f-4feb-b292-f3e8958a59d3",
+            "name": "Brian's First Quiz",
+            "questions": [
                 {
-                    "kind": "response",
+                    "kind": "question",
+                    "object_id": "751f9e7a-cbcc-41d8-816e-d65f6fdafe23",
                     "type": "multiple_choice",
-                    "choice": "Mike",
-                    "user_id": "1345125",
-                    "nickname": "Brian"
-                }
-            ]
-        },
-        {
-            "kind": "question",
-            "object_id": "3e77b67d-0f2a-421f-8bde-c1abbc99af99",
-            "type": "matching",
-            "prompt": "Match the following questions",
-            "left_choices": {
-                "A": "Mike",
-                "B": "Ike"
-            },
-            "right_choices": {
-                "C": "Ike",
-                "D": "Mike"
-            },
-            "answer": {
-                "A": "C",
-                "B": "D"
-            },
-            "responses": [
+                    "prompt": "Who is the best?",
+                    "choices": [
+                        "Mike",
+                        "Domingo"
+                    ],
+                    "answer": "Mike",
+                    "responses": [
+                        {
+                            "kind": "response",
+                            "type": "multiple_choice",
+                            "choice": "Mike",
+                            "user_id": "1345125",
+                            "nickname": "Brian"
+                        }
+                    ]
+                },
                 {
-                    "kind": "response",
+                    "kind": "question",
+                    "object_id": "3e77b67d-0f2a-421f-8bde-c1abbc99af99",
                     "type": "matching",
-                    "answer_mapping": {
-                        "A": "C",
-                        "B": "D"
+                    "prompt": "Match the following questions",
+                    "left_choices": [
+                        "Mike",
+                        "Ike"
+                    ],
+                    "right_choices": [
+                        "Ike",
+                        "Mike"
+                    ],
+                    "answer": {
+                        "Ike": "Mike",
+                        "Mike": "Ike"
                     },
-                    "user_id": "1345125",
-                    "nickname": "Brian"
-                }
-            ]
-        },
-        {
-            "kind": "question",
-            "object_id": "e25a2238-544d-4581-917b-f74916b0060f",
-            "type": "short_answer",
-            "prompt": "Who is the best?",
-            "answer": "YOU",
-            "responses": [
+                    "responses": [
+                        {
+                            "kind": "response",
+                            "type": "matching",
+                            "answer_mapping": {
+                                "Mike": "Ike",
+                                "Ike": "Mike"
+                            },
+                            "user_id": "1345125",
+                            "nickname": "Brian"
+                        }
+                    ]
+                },
                 {
-                    "kind": "response",
+                    "kind": "question",
+                    "object_id": "e25a2238-544d-4581-917b-f74916b0060f",
                     "type": "short_answer",
-                    "short_answer": "YOU",
-                    "user_id": "1345125",
-                    "nickname": "Brian"
-                }
-            ]
-        },
-        {
-            "kind": "question",
-            "object_id": "cc4b4a25-2390-40f3-bc8c-7efe263d9212",
-            "type": "fill_in_the_blank",
-            "before_prompt": "",
-            "after_prompt": "are the best",
-            "answer": "YOU",
-            "responses": [
+                    "prompt": "Who is the best?",
+                    "answer": "YOU",
+                    "responses": [
+                        {
+                            "kind": "response",
+                            "type": "short_answer",
+                            "short_answer": "YOU",
+                            "user_id": "1345125",
+                            "nickname": "Brian"
+                        }
+                    ]
+                },
                 {
-                    "kind": "response",
+                    "kind": "question",
+                    "object_id": "cc4b4a25-2390-40f3-bc8c-7efe263d9212",
                     "type": "fill_in_the_blank",
-                    "blank_answer": "YOU",
-                    "user_id": "1345125",
-                    "nickname": "Brian"
+                    "before_prompt": "",
+                    "after_prompt": "are the best",
+                    "answer": "YOU",
+                    "responses": [
+                        {
+                            "kind": "response",
+                            "type": "fill_in_the_blank",
+                            "blank_answer": "YOU",
+                            "user_id": "1345125",
+                            "nickname": "Brian"
+                        }
+                    ]
                 }
             ]
         }
-    ]
-}
         self.quiz = Quiz.load_quiz_from_json(self.quiz_json)
 
     def test_load_quiz_from_json(self):


### PR DESCRIPTION
Instead of using a dictionary to represent choices for matching and multiple choice questions a list is used and insertion order is maintained while removing duplicates by using a list(dict.fromkeys()) constructor for arguments. In addition, some logic for validating consisting state has been added.